### PR TITLE
Fix source-map-support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,12 +1,11 @@
 var gulp = require("gulp"),
-    util = require("gulp-util"),
-    mocha = require("gulp-mocha")
+    mocha = require("gulp-mocha"),
     compiler = require("gulp-babel"),
     sourcemap = require("gulp-sourcemaps");
-    header = require("gulp-header"),
     eslint = require('gulp-eslint'),
     plumber = require('gulp-plumber'),
-    rimraf = require('gulp-rimraf');
+    rimraf = require('gulp-rimraf'),
+    sourceMapSupport = require('source-map-support');
 
 gulp.task('default', ['test']);
 
@@ -15,16 +14,16 @@ gulp.task("watch", function(){
 });
 
 gulp.task('test', ['clean','compile'], function(){
+  sourceMapSupport.install();
   return gulp.src("build/src/**/*.spec.js")
     .pipe(mocha());
 });
 
 gulp.task('compile',['lint'], function(){
   return gulp.src('src/**/*.js')
-    .pipe(header("require('source-map-support').install();"))
     .pipe(sourcemap.init())
     .pipe(compiler())
-    .pipe(sourcemap.write("."))
+    .pipe(sourcemap.write('.', {sourceRoot: '../../src/'}))
     .pipe(gulp.dest("build/src"));
 });
 

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
   "homepage": "https://github.com/goodeggs/goodeggs-validators",
   "bugs": "https://github.com/goodeggs/goodeggs-validators/issues",
   "main": "build/src/index.js",
-  "dependencies": {
-    "source-map-support": "^0.4.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel": "^6.5.2",
     "babel-eslint": "^6.1.2",
@@ -24,12 +22,11 @@
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-eslint": "^0.14.0",
-    "gulp-header": "^1.2.2",
     "gulp-mocha": "^2.1.2",
     "gulp-plumber": "^1.0.1",
     "gulp-rimraf": "^0.2.0",
-    "gulp-sourcemaps": "^1.5.2",
-    "gulp-util": "^3.0.5"
+    "gulp-sourcemaps": "~1.5.2",
+    "source-map-support": "^0.4.18"
   },
   "scripts": {
     "prepublish": "gulp compile",


### PR DESCRIPTION
Don't include it as a normal dependency so that it doesn't clobber host environment source-map-support config; instead, use it for tests to get good line numbers for test failures.